### PR TITLE
Ignore extra columns in peoples sheet

### DIFF
--- a/lib/google_spreadsheet.rb
+++ b/lib/google_spreadsheet.rb
@@ -27,7 +27,9 @@ class GoogleSpreadsheet
   end
 
   def people
-    @spreadsheet.worksheets[1].rows[1..-1].flatten
+    @spreadsheet.worksheets[1].rows[1..-1].map do |name, _|
+      name
+    end
   end
 
   def title


### PR DESCRIPTION
This will always use the first column. Makes it possible to add extra
information, like account number.
